### PR TITLE
Wasm arrays as arguments and return types

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 wasm-bindgen = "0.2.63"
+js-sys = "0.3.60"

--- a/packages/ergo-wasm-derive/Cargo.toml
+++ b/packages/ergo-wasm-derive/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ergo-wasm-derive"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "1.0"
+quote = "1.0"
+proc-macro2 = "1.0"
+wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }
+js-sys = "0.3.51"
+darling = "0.14.2"

--- a/packages/ergo-wasm-derive/src/lib.rs
+++ b/packages/ergo-wasm-derive/src/lib.rs
@@ -449,11 +449,10 @@ pub fn derive_try_js_array_to_vec(input: TokenStream) -> TokenStream {
             type ReturnType = #name;
 
             fn try_as_vec(&self) -> Result<Vec<Self::ReturnType>, ::wasm_bindgen::JsValue> {
-                let js_array: &::js_sys::Array = self.dyn_ref().unwrap();
-                let length: usize = js_array.length().try_into().unwrap();
-                let mut rust_vec = Vec::<Self::ReturnType>::with_capacity(length);
+                let js_array: &::js_sys::Array = self.dyn_ref().map_or_else(|| Err(JsValue::from_str("try_as_vec: argument wasn't an array type")), |v| Ok(v))?;
+                let mut rust_vec = Vec::<Self::ReturnType>::with_capacity(js_array.length() as usize);
                 for js in js_array.iter() {
-                    let elem = ::std::convert::TryFrom::try_from(&js).unwrap();
+                    let elem = ::std::convert::TryFrom::try_from(&js)?;
                     rust_vec.push(elem);
                 }
 

--- a/packages/ergo-wasm-derive/src/lib.rs
+++ b/packages/ergo-wasm-derive/src/lib.rs
@@ -1,0 +1,402 @@
+/*!
+This is a specialized crate exporting a derive macro [`TryFromJsValue`]
+that serves as a basis for workarounds for some lapses of functionality in
+[`wasm-bindgen`](https://crates.io/crates/wasm-bindgen).
+
+
+## Optional arguments
+
+`wasm-bindgen` supports method arguments of the form `Option<T>`,
+where `T` is an exported type, but it has an unexpected side effect on the JS side:
+the value passed to a method this way gets consumed (mimicking Rust semantics).
+See [this issue](https://github.com/rustwasm/wasm-bindgen/issues/2370).
+`Option<&T>` is not currently supported, but an equivalent behavior can be implemented manually.
+
+```
+use js_sys::Error;
+use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
+use wasm_bindgen_derive::TryFromJsValue;
+
+// Derive `TryFromJsValue` for the target structure (note that it has to come
+// before the `[#wasm_bindgen]` attribute, and requires `Clone`):
+#[derive(TryFromJsValue)]
+#[wasm_bindgen]
+#[derive(Clone)]
+struct MyType(usize);
+
+// To have a correct typing annotation generated for TypeScript, declare a custom type.
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "MyType | null")]
+    pub type OptionMyType;
+}
+
+// Use this type in the function signature.
+pub fn foo(value: &OptionMyType) -> Result<usize, Error> {
+    let js_value: &JsValue = value.as_ref();
+    let typed_value: Option<MyType> = if js_value.is_null() {
+        None
+    } else {
+        Some(MyType::try_from(js_value).map_err(|err| Error::new(&err))?)
+    };
+    // Use the typed value
+    Ok(typed_value.map(|value| value.0).unwrap_or_default())
+}
+```
+
+## Vector arguments
+
+`wasm-bindgen` currently does not support vector arguments with elements having an exported type.
+See [this issue](https://github.com/rustwasm/wasm-bindgen/issues/111),
+which, although it is mainly about returning vectors, will probably allow taking vectors too
+when fixed.
+
+The workaround is similar to that for the optional arguments, with one step added,
+where we try to cast the [`JsValue`](`wasm_bindgen::JsValue`) into [`Array`](`js_sys::Array`).
+The following example also shows how to return an array with elements having an exported type.
+
+```
+use js_sys::Error;
+use wasm_bindgen::JsCast;
+use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
+use wasm_bindgen_derive::TryFromJsValue;
+
+#[derive(TryFromJsValue)]
+#[wasm_bindgen]
+#[derive(Clone)]
+struct MyType(usize);
+
+// To have a correct typing annotation generated for TypeScript, declare a custom type.
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "MyType[]")]
+    pub type MyTypeArray;
+}
+
+// Use this type in the function signature.
+pub fn foo(val: &MyTypeArray) -> Result<MyTypeArray, Error> {
+
+    // Unpack the array
+
+    let js_val: &JsValue = val.as_ref();
+    if !js_sys::Array::is_array(js_val) {
+        return Err(Error::new("The argument must be an array"));
+    }
+    let array = js_sys::Array::from(js_val);
+    let length: usize = array.length().try_into().map_err(|err| Error::new(&format!("{}", err)))?;
+    let mut typed_array = Vec::<MyType>::with_capacity(length);
+    for js in array.iter() {
+        let typed_elem = MyType::try_from(&js).map_err(|err| Error::new(&err))?;
+        typed_array.push(typed_elem);
+    }
+
+    // Now we have `typed_array: Vec<MyType>`.
+
+    // Return the array
+
+    Ok(typed_array
+        .into_iter()
+        .map(JsValue::from)
+        .collect::<js_sys::Array>()
+        .unchecked_into::<MyTypeArray>())
+}
+```
+*/
+#![doc(html_root_url = "https://docs.rs/wasm-bindgen-derive")]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+
+extern crate alloc;
+
+use alloc::format;
+use alloc::string::ToString;
+
+use darling::FromDeriveInput;
+use proc_macro::TokenStream;
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use quote::{format_ident, quote};
+use syn::{parse_macro_input, Data, DeriveInput, Error};
+
+macro_rules! derive_error {
+    ($string: tt) => {
+        Error::new(Span::call_site(), $string)
+            .to_compile_error()
+            .into()
+    };
+}
+
+/** Derives a `TryFrom<&JsValue>` for a type exported using `#[wasm_bindgen]`.
+
+Note that:
+* this derivation must be be positioned before `#[wasm_bindgen]`;
+* the type must implement [`Clone`].
+* `extern crate alloc` must be declared in scope.
+
+The macro is authored by [**@AlexKorn**](https://github.com/AlexKorn)
+based on the idea of [**@aweinstock314**](https://github.com/aweinstock314).
+See [this](https://github.com/rustwasm/wasm-bindgen/issues/2231#issuecomment-656293288)
+and [this](https://github.com/rustwasm/wasm-bindgen/issues/2231#issuecomment-1169658111)
+GitHub comments.
+*/
+#[proc_macro_derive(TryFromJsValue)]
+pub fn derive_try_from_jsvalue(input: TokenStream) -> TokenStream {
+    let input: DeriveInput = parse_macro_input!(input as DeriveInput);
+
+    let name = input.ident;
+    let data = input.data;
+
+    match data {
+        Data::Struct(_) => {}
+        _ => return derive_error!("TryFromJsValue may only be derived on structs"),
+    };
+
+    let wasm_bindgen_meta = input.attrs.iter().find_map(|attr| {
+        attr.parse_meta()
+            .ok()
+            .and_then(|meta| match meta.path().is_ident("wasm_bindgen") {
+                true => Some(meta),
+                false => None,
+            })
+    });
+    if wasm_bindgen_meta.is_none() {
+        return derive_error!(
+            "TryFromJsValue can be defined only on struct exported to wasm with #[wasm_bindgen]"
+        );
+    }
+
+    let maybe_js_class = wasm_bindgen_meta
+        .and_then(|meta| match meta {
+            syn::Meta::List(list) => Some(list),
+            _ => None,
+        })
+        .and_then(|meta_list| {
+            meta_list.nested.iter().find_map(|nested_meta| {
+                let maybe_meta = match nested_meta {
+                    syn::NestedMeta::Meta(meta) => Some(meta),
+                    _ => None,
+                };
+
+                maybe_meta
+                    .and_then(|meta| match meta {
+                        syn::Meta::NameValue(name_value) => Some(name_value),
+                        _ => None,
+                    })
+                    .and_then(|name_value| match name_value.path.is_ident("js_name") {
+                        true => Some(name_value.lit.clone()),
+                        false => None,
+                    })
+                    .and_then(|lit| match lit {
+                        syn::Lit::Str(str) => Some(str.value()),
+                        _ => None,
+                    })
+            })
+        });
+
+    let wasm_bindgen_macro_invocaton = match maybe_js_class {
+        Some(class) => format!("wasm_bindgen(js_class = \"{}\")", class),
+        None => "wasm_bindgen".to_string(),
+    }
+    .parse::<TokenStream2>()
+    .unwrap();
+
+    let expanded = quote! {
+        impl #name {
+            pub fn __get_classname() -> &'static str {
+                ::core::stringify!(#name)
+            }
+        }
+
+        #[#wasm_bindgen_macro_invocaton]
+        impl #name {
+            #[wasm_bindgen(js_name = "__getClassname")]
+            pub fn __js_get_classname(&self) -> String {
+                use ::alloc::borrow::ToOwned;
+                ::core::stringify!(#name).to_owned()
+            }
+        }
+
+        impl ::core::convert::TryFrom<&::wasm_bindgen::JsValue> for #name {
+            type Error = ::wasm_bindgen::JsValue;
+
+            fn try_from(js: &::wasm_bindgen::JsValue) -> Result<Self, Self::Error> {
+                use ::alloc::borrow::ToOwned;
+                use ::alloc::string::ToString;
+                use ::wasm_bindgen::JsCast;
+                use ::wasm_bindgen::convert::RefFromWasmAbi;
+
+                let classname = Self::__get_classname();
+
+                if !js.is_object() {
+                    return Err(::wasm_bindgen::JsValue::from_str(format!("Value supplied as {} is not an object", classname).as_str()));
+                }
+
+                let no_get_classname_msg = concat!(
+                    "no __getClassname method specified for object; ",
+                    "did you forget to derive TryFromJsObject for this type?");
+
+                let get_classname = ::js_sys::Reflect::get(
+                    js,
+                    &::wasm_bindgen::JsValue::from("__getClassname"),
+                )
+                .or(Err(::wasm_bindgen::JsValue::from_str(no_get_classname_msg)))?;
+
+                if get_classname.is_undefined() {
+                    return Err(::wasm_bindgen::JsValue::from_str(no_get_classname_msg));
+                }
+
+                let get_classname = get_classname
+                    .dyn_into::<::js_sys::Function>()
+                    .map_err(|err| ::wasm_bindgen::JsValue::from_str(format!("__getClassname is not a function, {:?}", err).as_str()))?;
+
+                let object_classname: String = ::js_sys::Reflect::apply(
+                        &get_classname,
+                        js,
+                        &::js_sys::Array::new(),
+                    )
+                    .ok()
+                    .and_then(|v| v.as_string())
+                    .ok_or_else(|| ::wasm_bindgen::JsValue::from_str("Failed to get classname"))?;
+
+                if object_classname.as_str() == classname {
+                    let ptr = ::js_sys::Reflect::get(js, &::wasm_bindgen::JsValue::from_str("ptr"))
+                        .map_err(|err| ::wasm_bindgen::JsValue::from_str(format!("{:?}", err).as_str()))?;
+                    let ptr_u32: u32 = ptr.as_f64().ok_or(::wasm_bindgen::JsValue::NULL)
+                        .map_err(|err| ::wasm_bindgen::JsValue::from_str(format!("{:?}", err).as_str()))?
+                        as u32;
+                    let instance_ref = unsafe { #name::ref_from_abi(ptr_u32) };
+                    Ok(instance_ref.clone())
+                } else {
+                    Err(::wasm_bindgen::JsValue::from_str(format!("Cannot convert {} to {}", object_classname, classname).as_str()))
+                }
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
+#[derive(FromDeriveInput)]
+#[darling(attributes(ergo))]
+struct TryVecToJsArrayOpts {
+    array_type: syn::Ident,
+}
+
+#[proc_macro_derive(TryVecToJsArray, attributes(ergo))]
+pub fn derive_try_vec_to_js_array(input: TokenStream) -> TokenStream {
+    let input: DeriveInput = parse_macro_input!(input as DeriveInput);
+    let input_ref = &input;
+    let attrs = TryVecToJsArrayOpts::from_derive_input(input_ref).unwrap();
+    let name = input.ident;
+    let data = input.data;
+
+    match data {
+        Data::Struct(_) => {}
+        _ => return derive_error!("TryVecToJsArray may only be derived on structs"),
+    };
+
+    let wasm_bindgen_meta = input.attrs.iter().find_map(|attr| {
+        attr.parse_meta()
+            .ok()
+            .and_then(|meta| match meta.path().is_ident("wasm_bindgen") {
+                true => Some(meta),
+                false => None,
+            })
+    });
+    if wasm_bindgen_meta.is_none() {
+        return derive_error!(
+            "TryVecToJsArray can be defined only on struct exported to wasm with #[wasm_bindgen]"
+        );
+    }
+
+    let trait_name = format_ident!("__{}__TryToJsArray", name);
+    let return_type = format_ident!("{}", attrs.array_type);
+
+    let expanded = quote! {
+        #[allow(non_camel_case_types)]
+        pub trait #trait_name {
+            type ReturnType;
+
+            fn try_into_js_array(self) -> Result<Self::ReturnType, JsValue>;
+            fn try_as_js_array(&self) -> Result<Self::ReturnType, JsValue>;
+        }
+
+        impl #trait_name for Vec<#name> {
+            type ReturnType = #return_type;
+
+            fn try_into_js_array(self) -> Result<Self::ReturnType, JsValue> {
+                Ok(self
+                    .into_iter()
+                    .map(::wasm_bindgen::JsValue::from)
+                    .collect::<::js_sys::Array>()
+                    .unchecked_into::<Self::ReturnType>())
+            }
+
+            fn try_as_js_array(&self) -> Result<Self::ReturnType, JsValue> {
+                Ok(self
+                    .iter()
+                    .map(|f| ::wasm_bindgen::JsValue::from(f.clone()))
+                    .collect::<::js_sys::Array>()
+                    .unchecked_into::<Self::ReturnType>())
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
+#[proc_macro_derive(TryJsArrayToVec, attributes(ergo))]
+pub fn derive_try_js_array_to_vec(input: TokenStream) -> TokenStream {
+    let input: DeriveInput = parse_macro_input!(input as DeriveInput);
+    let input_ref = &input;
+    let attrs = TryVecToJsArrayOpts::from_derive_input(input_ref).unwrap();
+    let name = input.ident;
+    let data = input.data;
+
+    match data {
+        Data::Struct(_) => {}
+        _ => return derive_error!("TryJsArrayToVec may only be derived on structs"),
+    };
+
+    let wasm_bindgen_meta = input.attrs.iter().find_map(|attr| {
+        attr.parse_meta()
+            .ok()
+            .and_then(|meta| match meta.path().is_ident("wasm_bindgen") {
+                true => Some(meta),
+                false => None,
+            })
+    });
+    if wasm_bindgen_meta.is_none() {
+        return derive_error!(
+            "TryJsArrayToVec can be defined only on struct exported to wasm with #[wasm_bindgen]"
+        );
+    }
+
+    let trait_name = format_ident!("__{}__TryJsArrayToVec", name);
+    let array_type = format_ident!("{}", attrs.array_type);
+
+    let expanded = quote! {
+        #[allow(non_camel_case_types)]
+        pub trait #trait_name {
+            type ReturnType;
+
+            fn try_as_vec(&self) -> Result<Vec<Self::ReturnType>, JsValue>;
+        }
+
+        impl #trait_name for &#array_type {
+            type ReturnType = #name;
+
+            fn try_as_vec(&self) -> Result<Vec<Self::ReturnType>, JsValue> {
+                let js_array: &::js_sys::Array = self.dyn_ref().unwrap();
+                let length: usize = js_array.length().try_into().unwrap();
+                let mut rust_vec = Vec::<Self::ReturnType>::with_capacity(length);
+                for js in js_array.iter() {
+                    let elem = ::std::convert::TryFrom::try_from(&js).unwrap();
+                    rust_vec.push(elem);
+                }
+
+                Ok(rust_vec)
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}

--- a/packages/ergo-wasm-derive/src/lib.rs
+++ b/packages/ergo-wasm-derive/src/lib.rs
@@ -340,14 +340,14 @@ pub fn derive_try_vec_to_js_array(input: TokenStream) -> TokenStream {
         pub trait #trait_name {
             type ReturnType;
 
-            fn try_into_js_array(self) -> Result<Self::ReturnType, JsValue>;
-            fn try_as_js_array(&self) -> Result<Self::ReturnType, JsValue>;
+            fn try_into_js_array(self) -> Result<Self::ReturnType, ::wasm_bindgen::JsValue>;
+            fn try_as_js_array(&self) -> Result<Self::ReturnType, ::wasm_bindgen::JsValue>;
         }
 
         impl #trait_name for Vec<#name> {
             type ReturnType = #return_type;
 
-            fn try_into_js_array(self) -> Result<Self::ReturnType, JsValue> {
+            fn try_into_js_array(self) -> Result<Self::ReturnType, ::wasm_bindgen::JsValue> {
                 Ok(self
                     .into_iter()
                     .map(::wasm_bindgen::JsValue::from)
@@ -355,7 +355,7 @@ pub fn derive_try_vec_to_js_array(input: TokenStream) -> TokenStream {
                     .unchecked_into::<Self::ReturnType>())
             }
 
-            fn try_as_js_array(&self) -> Result<Self::ReturnType, JsValue> {
+            fn try_as_js_array(&self) -> Result<Self::ReturnType, ::wasm_bindgen::JsValue> {
                 Ok(self
                     .iter()
                     .map(|f| ::wasm_bindgen::JsValue::from(f.clone()))
@@ -442,13 +442,13 @@ pub fn derive_try_js_array_to_vec(input: TokenStream) -> TokenStream {
         pub trait #trait_name {
             type ReturnType;
 
-            fn try_as_vec(&self) -> Result<Vec<Self::ReturnType>, JsValue>;
+            fn try_as_vec(&self) -> Result<Vec<Self::ReturnType>, ::wasm_bindgen::JsValue>;
         }
 
         impl #trait_name for &#array_type {
             type ReturnType = #name;
 
-            fn try_as_vec(&self) -> Result<Vec<Self::ReturnType>, JsValue> {
+            fn try_as_vec(&self) -> Result<Vec<Self::ReturnType>, ::wasm_bindgen::JsValue> {
                 let js_array: &::js_sys::Array = self.dyn_ref().unwrap();
                 let length: usize = js_array.length().try_into().unwrap();
                 let mut rust_vec = Vec::<Self::ReturnType>::with_capacity(length);

--- a/packages/merkle-tree/Cargo.toml
+++ b/packages/merkle-tree/Cargo.toml
@@ -18,6 +18,9 @@ getrandom = {version = "0.2.3", features = ["js"]}
 derive_more = "0.99.17"
 serde-wasm-bindgen = "0.4.5"
 serde = { version = "1.0", features = ["derive"] }
+wasm-bindgen-derive = "0.1.0"
+ergo-wasm-derive = { path = "../ergo-wasm-derive" }
+ergo-wasm-common = { path = "../../common" }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"

--- a/packages/merkle-tree/src/lib.rs
+++ b/packages/merkle-tree/src/lib.rs
@@ -1,4 +1,3 @@
-extern crate alloc;
 use ergo_wasm_derive::{TryFromJsValue, TryJsArrayToVec, TryVecToJsArray};
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
@@ -79,11 +78,6 @@ impl MerkleProof {
     #[wasm_bindgen(constructor)]
     pub fn new(leaf_data: &[u8]) -> MerkleProof {
         Self(ergo_merkle_tree::MerkleProof::new(leaf_data, &[])) // There are issues with wasm when trying to pass an array of structs, so it's better to use add_node instead
-    }
-
-    pub fn test_arrays(js_levels: &LevelNodeArray) -> LevelNodeArray {
-        let typed_array: Vec<LevelNode> = js_levels.try_as_vec().unwrap();
-        typed_array.try_into_js_array().unwrap()
     }
 
     /// Adds a new node to the MerkleProof above the current nodes

--- a/packages/merkle-tree/tests/merkle-tree.test.ts
+++ b/packages/merkle-tree/tests/merkle-tree.test.ts
@@ -1,4 +1,4 @@
-import { LevelNode, MerkleProof, WasmTestStruct, WasmVecStruct } from "../";
+import { LevelNode, MerkleProof } from "../";
 
 function hexToBytes(hexStr: string): Uint8Array {
   return Uint8Array.from(
@@ -23,18 +23,9 @@ describe("MerkleProof", () => {
       );
 
       const proof = new MerkleProof(txId);
-      const proof2 = MerkleProof.new_with_nodes(txId, [levelNodes]);
       proof.addNode(levelNodes);
 
-      const levels3 = [levelNodes];
-      console.log(levels3);
-      const levels2 = MerkleProof.test_arrays(levels3);
-
-      console.log(levels2);
-      console.log(levels3);
-      expect(levels2.length).toBe(1);
       expect(proof.isValid(txRoot)).toBe(true);
-      expect(proof2.isValid(txRoot)).toBe(true);
     });
   });
 });

--- a/packages/merkle-tree/tests/merkle-tree.test.ts
+++ b/packages/merkle-tree/tests/merkle-tree.test.ts
@@ -1,4 +1,4 @@
-import { LevelNode, MerkleProof } from "../";
+import { LevelNode, MerkleProof, WasmTestStruct, WasmVecStruct } from "../";
 
 function hexToBytes(hexStr: string): Uint8Array {
   return Uint8Array.from(
@@ -23,9 +23,18 @@ describe("MerkleProof", () => {
       );
 
       const proof = new MerkleProof(txId);
+      const proof2 = MerkleProof.new_with_nodes(txId, [levelNodes]);
       proof.addNode(levelNodes);
 
+      const levels3 = [levelNodes];
+      console.log(levels3);
+      const levels2 = MerkleProof.test_arrays(levels3);
+
+      console.log(levels2);
+      console.log(levels3);
+      expect(levels2.length).toBe(1);
       expect(proof.isValid(txRoot)).toBe(true);
+      expect(proof2.isValid(txRoot)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Changes

This PR adds the following:

- Allows downcasting a `JsValue` into a rust struct that is wasm binded (required for the below 2 array ops)
- Allow rust accepting array of wasm structs from JS
- Allow returning array of structs from rust to JS

Related `wasm-bindgen` issues:

- https://github.com/rustwasm/wasm-bindgen/issues/2231
- https://github.com/rustwasm/wasm-bindgen/issues/111

The problem with using JSON / `serde` for handling passing/receiving arrays is that deser/ser converts to JS objects instead of classes so library consumers can't use class methods without converting to or from JSON first. With the derives added in this PR this is no longer needed

Simple example not using arrays but to describe the problem with JSON:

Rust

```rust
#[wasm_bindgen]
#[derive(Serialize, Deserialize)]
pub struct MyType(usize);

#[wasm_bindgen]
impl MyType {
    pub fn new(&self, n: usize) -> MyType {
        MyType(n)
    }

    pub fn inner_num(&self) -> usize {
        self.0
    }

    pub fn to_json(&self) -> Result<JsValue, serde_wasm_bindgen::Error> {
        serde_wasm_bindgen::to_value(&self.0)
    }
}
```

JS

```javascript
const myType = MyType.new(5);
const myTypeJson = myType.to_json();

myType.inner_num(); // 5
myTypeJson.inner_num(); // doesn't work, json object doesn't have the func

const jsonBackToMyType = MyType.from_json(myTypeJson);
jsonBackToMyType.inner_num(); // 5
```

The hope is one day `wasm_bindgen` supports vecs of structs so we can remove this 😄 