### PR TITLE
Start porting ergo-tree constants

### DIFF
--- a/packages/ergo-lib-wasm/src/ir.rs
+++ b/packages/ergo-lib-wasm/src/ir.rs
@@ -1,0 +1,1 @@
+mod constants;

--- a/packages/ergo-lib-wasm/src/ir/constants.rs
+++ b/packages/ergo-lib-wasm/src/ir/constants.rs
@@ -211,9 +211,7 @@ impl SColl {
 
 impl DynLiftIntoSType for SColl {
     fn dyn_stype(&self) -> SType {
-        let elem = self.elem_tpe();
-
-        SType::SColl(Box::new(elem))
+        SType::SColl(Box::new(self.elem_tpe()))
     }
 }
 

--- a/packages/ergo-lib-wasm/src/js.rs
+++ b/packages/ergo-lib-wasm/src/js.rs
@@ -1,0 +1,25 @@
+use js_sys::{Array, Function, Reflect};
+use wasm_bindgen::{JsCast, JsValue};
+
+/// Used to lower a `JsValue` on the rust side to a concrete rust struct
+/// that has been binded with `wasm_bindgen`.
+///
+/// `TryFromJsValue` derive macro defines the `__getClassname` function
+/// to enable this conversion.
+pub(crate) fn extract_classname(value: &JsValue) -> Result<String, JsValue> {
+    let classname = Reflect::get(value, &JsValue::from("__getClassname"))
+        .map_err(|_| JsValue::from_str("failed to lookup __getClassname property"))?;
+
+    if classname.is_undefined() {
+        return Err("__getClassname undefined".into());
+    }
+
+    let classname_func = classname.dyn_into::<Function>().map_err(|err| {
+        JsValue::from_str(format!("__getClassname is not a function, {:?}", err).as_str())
+    })?;
+
+    Reflect::apply(&classname_func, value, &Array::new())
+        .ok()
+        .and_then(|v| v.as_string())
+        .ok_or_else(|| JsValue::from_str("Failed to get classname"))
+}

--- a/packages/ergo-lib-wasm/src/lib.rs
+++ b/packages/ergo-lib-wasm/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod address;
 pub mod blockchain;
 pub mod ergo_tree;
+pub mod ir;
+pub mod js;
 pub mod macros;
 pub mod merkle_tree;
 pub mod nipopow;

--- a/packages/ergo-lib-wasm/tests/ir/constants.test.ts
+++ b/packages/ergo-lib-wasm/tests/ir/constants.test.ts
@@ -1,4 +1,4 @@
-import { SColl, SByte, SInt } from "../../";
+import { SColl, SByte, SInt, SLong } from "../../";
 
 describe("Constants", () => {
   describe("Functional parity with library v0.x.x", () => {
@@ -47,6 +47,13 @@ describe("Constants", () => {
         ]).intoConstant();
 
         expect(constant.toHex()).toBe("10070802040a000410");
+      });
+    });
+    describe("i64 support", () => {
+      it("should handle the max value of i64", () => {
+        const constant = new SLong(BigInt("9223372036854775807")); // max i64 value
+
+        expect(constant.value).toBe(BigInt("9223372036854775807"));
       });
     });
   });

--- a/packages/ergo-lib-wasm/tests/ir/constants.test.ts
+++ b/packages/ergo-lib-wasm/tests/ir/constants.test.ts
@@ -1,0 +1,53 @@
+import { SColl, SByte, SInt } from "../../";
+
+describe("Constants", () => {
+  describe("Functional parity with library v0.x.x", () => {
+    describe("Constant.from_byte_array(new Uint8Array([3, 2, 1]))", () => {
+      it("should serialize to the same value", () => {
+        const constant = new SColl([
+          new SByte(3),
+          new SByte(2),
+          new SByte(1),
+        ]).intoConstant();
+
+        expect(constant.toHex()).toBe("0e03030201");
+      });
+    });
+    describe("ergo.Constant.from_i32_array([4, 1, 2])", () => {
+      it("should serialize to the same value", () => {
+        const constant = new SColl([
+          new SInt(4),
+          new SInt(1),
+          new SInt(2),
+        ]).intoConstant();
+
+        expect(constant.toHex()).toBe("1003080204");
+      });
+    });
+    describe("Constant.from_coll_coll_byte([new Uint8Array([4, 1, 2, 3]), new Uint8Array([1, 2, 3])])", () => {
+      it("should serialize to the same value", () => {
+        const constant = new SColl([
+          new SColl([new SByte(4), new SByte(1), new SByte(2), new SByte(3)]),
+          new SColl([new SByte(1), new SByte(2), new SByte(3)]),
+        ]).intoConstant();
+
+        expect(constant.toHex()).toBe("1a02040401020303010203");
+      });
+    });
+    describe("Constant.from_i32_array([4, 1, 2, 5, 0, 2, 8])", () => {
+      it("should serialize to the same value", () => {
+        const constant = new SColl([
+          new SInt(4),
+          new SInt(1),
+          new SInt(2),
+          new SInt(5),
+          new SInt(0),
+          new SInt(2),
+          new SInt(8),
+        ]).intoConstant();
+
+        expect(constant.toHex()).toBe("10070802040a000410");
+      });
+    });
+  });
+});


### PR DESCRIPTION
@greenhat 

Will add the rest of the `Constant` methods in next PRs, just want to check that you're happy with the direction I'm going.

Allowing more flexibility in how `Constant`s are created as opposed to specific constructor methods like `Constant.from_coll_coll_byte` like we have at the moment. `constants.test.ts` tests should show examples of before vs after