### PR TITLE
Convert constant literal to js values

### DIFF
--- a/packages/ergo-lib-wasm/src/ir/constants.rs
+++ b/packages/ergo-lib-wasm/src/ir/constants.rs
@@ -230,9 +230,9 @@ impl From<Literal> for SLiteral {
             Literal::Long(v) => SLiteral::Long(v.into()),
             Literal::BigInt(v) => SLiteral::BigInt(v.into()),
             Literal::SigmaProp(v) => SLiteral::SigmaProp((*v).into()),
-            Literal::GroupElement(v) => SLiteral::GroupElement((*v).into()),
+            Literal::GroupElement(v) => SLiteral::GroupElement(v.into()),
             Literal::AvlTree(_) => todo!(),
-            Literal::CBox(v) => SLiteral::ErgoBox((&*v).clone().into()),
+            Literal::CBox(v) => SLiteral::ErgoBox((*v).clone().into()),
             Literal::Coll(v) => SLiteral::Coll(v.into()),
             Literal::Opt(_) => todo!(),
             Literal::Tup(_) => todo!(),
@@ -375,7 +375,7 @@ impl SBigInt {
 
     #[wasm_bindgen(js_name = intoConstant)]
     pub fn into_constant(self) -> SConstant {
-        SConstant(self.0.clone().into())
+        SConstant(self.0.into())
     }
 }
 
@@ -408,7 +408,7 @@ impl SSigmaProp {
     #[wasm_bindgen(getter)]
     pub fn value(&self) -> JsValue {
         match self.0.value() {
-            SigmaBoolean::TrivialProp(bool) => bool.clone().into(),
+            SigmaBoolean::TrivialProp(bool) => (*bool).into(),
             SigmaBoolean::ProofOfKnowledge(_) => todo!(),
             SigmaBoolean::SigmaConjecture(_) => todo!(),
         }
@@ -416,7 +416,7 @@ impl SSigmaProp {
 
     #[wasm_bindgen(js_name = intoConstant)]
     pub fn into_constant(self) -> SConstant {
-        SConstant(self.0.clone().into())
+        SConstant(self.0.into())
     }
 }
 
@@ -429,22 +429,22 @@ impl From<SSigmaProp> for Literal {
 #[derive(TryFromJsValue)]
 #[wasm_bindgen]
 #[derive(Debug, Clone, From, Into)]
-pub struct SGroupElement(EcPoint);
+pub struct SGroupElement(Box<EcPoint>);
 
 #[wasm_bindgen]
 impl SGroupElement {
     #[wasm_bindgen(js_name = fromHex)]
     pub fn from_hex(hex: &str) -> Result<SGroupElement, JsValue> {
-        let ec: EcPoint = hex.to_string().try_into().map_err_js_value()?;
+        let ec: Box<EcPoint> = Box::new(hex.to_string().try_into().map_err_js_value()?);
 
         Ok(ec.into())
     }
 
     #[wasm_bindgen(js_name = fromBytes)]
     pub fn from_bytes(bytes: &Uint8Array) -> Result<SGroupElement, JsValue> {
-        Ok(EcPoint::sigma_parse_bytes(&bytes.to_vec())
-            .map_err_js_value()?
-            .into())
+        let ec = Box::new(EcPoint::sigma_parse_bytes(&bytes.to_vec()).map_err_js_value()?);
+
+        Ok(ec.into())
     }
 
     #[wasm_bindgen(getter)]
@@ -456,13 +456,13 @@ impl SGroupElement {
 
     #[wasm_bindgen(js_name = intoConstant)]
     pub fn into_constant(self) -> SConstant {
-        SConstant(self.0.clone().into())
+        SConstant((*self.0).into())
     }
 }
 
 impl From<SGroupElement> for Literal {
     fn from(prop: SGroupElement) -> Self {
-        prop.0.into()
+        (*prop.0).into()
     }
 }
 
@@ -495,7 +495,7 @@ impl SErgoBox {
 
     #[wasm_bindgen(js_name = intoConstant)]
     pub fn into_constant(self) -> SConstant {
-        SConstant(self.0.clone().into())
+        SConstant(self.0.into())
     }
 }
 
@@ -530,7 +530,7 @@ impl SColl {
 
     #[wasm_bindgen(js_name = intoConstant)]
     pub fn into_constant(self) -> Result<SConstant, JsValue> {
-        let inner: Constant = Value::from(Literal::from(self.clone()))
+        let inner: Constant = Value::from(Literal::from(self))
             .try_into()
             .map_err_js_value()?;
 

--- a/packages/ergo-lib-wasm/src/ir/constants.rs
+++ b/packages/ergo-lib-wasm/src/ir/constants.rs
@@ -136,9 +136,16 @@ impl SConstant {
                 SBigInt::new(js_sys::BigInt::from_str(v.to_string().as_str())?)?.into()
             }
             Literal::SigmaProp(v) => SSigmaProp::from(*v).into(),
-            Literal::GroupElement(_) => todo!(),
+            Literal::GroupElement(v) => {
+                SGroupElement::try_from((*v).sigma_serialize_bytes().map_err_js_value()?)?.into()
+            }
             Literal::AvlTree(_) => todo!(),
-            Literal::CBox(_) => todo!(),
+            Literal::CBox(v) => {
+                let native_box = &*v;
+                let ergo_box = ErgoBox::from(native_box.clone());
+
+                SErgoBox::new(&ergo_box).into()
+            }
             Literal::Coll(_) => todo!(),
             Literal::Opt(_) => todo!(),
             Literal::Tup(_) => todo!(),
@@ -472,6 +479,16 @@ impl SGroupElement {
 impl From<SGroupElement> for Literal {
     fn from(prop: SGroupElement) -> Self {
         prop.0.into()
+    }
+}
+
+impl TryFrom<Vec<u8>> for SGroupElement {
+    type Error = JsValue;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        let arr = Uint8Array::from(value.as_slice());
+
+        Self::from_bytes(&arr)
     }
 }
 

--- a/packages/ergo-lib-wasm/tests/ergo-tree.test.ts
+++ b/packages/ergo-lib-wasm/tests/ergo-tree.test.ts
@@ -35,7 +35,7 @@ describe("ErgoTree", () => {
       const treeConstant = updatedTree.getConstant(0)!;
 
       // TODO: need to be able to convert treeConstant to JS value
-      expect(true).toBe(true);
+      expect(treeConstant.literal.value).toBe(1337);
     });
     it("should throw when inserting constant at an out-of-bounds index", () => {
       const constant = new SInt(1337).intoConstant();

--- a/packages/ergo-lib-wasm/tests/ergo-tree.test.ts
+++ b/packages/ergo-lib-wasm/tests/ergo-tree.test.ts
@@ -34,7 +34,6 @@ describe("ErgoTree", () => {
       const updatedTree = tree.withConstant(0, constant);
       const treeConstant = updatedTree.getConstant(0)!;
 
-      // TODO: need to be able to convert treeConstant to JS value
       expect(treeConstant.literal.value).toBe(1337);
     });
     it("should throw when inserting constant at an out-of-bounds index", () => {

--- a/packages/ergo-lib-wasm/tests/ir/constants.test.ts
+++ b/packages/ergo-lib-wasm/tests/ir/constants.test.ts
@@ -10,6 +10,7 @@ import {
   ErgoBox,
   SErgoBox,
   SConstant,
+  SBoolean,
 } from "../../";
 
 describe("Constants", () => {
@@ -169,6 +170,18 @@ describe("Constants", () => {
         new SInt(8),
       ]);
       const expected = [4, 1, 2, 5, 0, 2, 8];
+
+      expect(value).toEqual(expected);
+    });
+    it("should handle nested collections", () => {
+      const { value } = new SColl([
+        new SColl([new SBoolean(true), new SBoolean(true)]),
+        new SColl([new SBoolean(false), new SBoolean(true)]),
+      ]);
+      const expected = [
+        [true, true],
+        [false, true],
+      ];
 
       expect(value).toEqual(expected);
     });

--- a/packages/ergo-lib-wasm/tests/ir/constants.test.ts
+++ b/packages/ergo-lib-wasm/tests/ir/constants.test.ts
@@ -157,4 +157,20 @@ describe("Constants", () => {
       });
     });
   });
+  describe("Conversion to JS value", () => {
+    it("should convert collection of SInt to array of int", () => {
+      const { value } = new SColl([
+        new SInt(4),
+        new SInt(1),
+        new SInt(2),
+        new SInt(5),
+        new SInt(0),
+        new SInt(2),
+        new SInt(8),
+      ]);
+      const expected = [4, 1, 2, 5, 0, 2, 8];
+
+      expect(value).toEqual(expected);
+    });
+  });
 });


### PR DESCRIPTION
Add conversion of constants+literals to JS values.

Remove `created_by`, the original intent was to use that as a way to provide the JS value but since constants can come from non-JS sources it doesn't really seem necessary to keep around. Just add conversion functions to convert stypes to JS values.

- [x] fix clippy