### PR TITLE
Fix lifting `JsValue` into rust struct

### DIFF
--- a/packages/ergo-wasm-derive/Cargo.toml
+++ b/packages/ergo-wasm-derive/Cargo.toml
@@ -10,5 +10,5 @@ proc-macro = true
 syn = "1.0"
 quote = "1.0"
 proc-macro2 = "1.0"
-wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }
-js-sys = "0.3.51"
+wasm-bindgen = "0.2.86"
+js-sys = "0.3.63"

--- a/packages/ergo-wasm-derive/src/lib.rs
+++ b/packages/ergo-wasm-derive/src/lib.rs
@@ -220,7 +220,6 @@ pub fn derive_try_from_jsvalue(input: TokenStream) -> TokenStream {
                 let no_get_classname_msg = concat!(
                     "no __getClassname method specified for object; ",
                     "did you forget to derive TryFromJsObject for this type?");
-
                 let get_classname = ::js_sys::Reflect::get(
                     js,
                     &::wasm_bindgen::JsValue::from("__getClassname"),
@@ -245,7 +244,7 @@ pub fn derive_try_from_jsvalue(input: TokenStream) -> TokenStream {
                     .ok_or_else(|| ::wasm_bindgen::JsValue::from_str("Failed to get classname"))?;
 
                 if object_classname.as_str() == classname {
-                    let ptr = ::js_sys::Reflect::get(js, &::wasm_bindgen::JsValue::from_str("ptr"))
+                    let ptr = ::js_sys::Reflect::get(js, &::wasm_bindgen::JsValue::from_str("__wbg_ptr"))
                         .map_err(|err| ::wasm_bindgen::JsValue::from_str(format!("{:?}", err).as_str()))?;
                     let ptr_u32: u32 = ptr.as_f64().ok_or(::wasm_bindgen::JsValue::NULL)
                         .map_err(|err| ::wasm_bindgen::JsValue::from_str(format!("{:?}", err).as_str()))?

--- a/packages/scorex-buffer/Cargo.toml
+++ b/packages/scorex-buffer/Cargo.toml
@@ -6,12 +6,6 @@ edition = "2021"
 [lib]
 crate_type = ["cdylib"]
 
-[profile.release]
-codegen-units = 1
-incremental = true
-lto = true
-opt-level = "z"
-
 [dependencies]
 wasm-bindgen = "0.2.83"
 sigma-ser = "0.11.0"


### PR DESCRIPTION
Closes #36 

Whatever generates WASM glue code renamed the `ptr` field to `__wbg_ptr` sometime in the last 3 months