### PR TITLE
Add console hook npm provenance

### DIFF
--- a/.changeset/kind-dodos-chew.md
+++ b/.changeset/kind-dodos-chew.md
@@ -1,0 +1,7 @@
+---
+"@ergoplatform/authenticated-avl-tree": patch
+"@ergoplatform/ergo-lib-wasm": patch
+"@ergoplatform/scorex-buffer": patch
+---
+
+add `__setConsolePanicHook` function to provide more detailed stack traces in the event of errors originating from WASM code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,8 @@ jobs:
   release:
     name: Release or Publish
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -19,10 +21,10 @@ jobs:
           toolchain: stable
       - name: Install wasm-pack
         run: cargo install wasm-pack
-      - name: Setup Node.js 16.x
+      - name: Setup Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Install Dependencies
         run: yarn --frozen-lockfile
       - name: Build
@@ -37,3 +39,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true

--- a/packages/authenticated-avl-tree/Cargo.toml
+++ b/packages/authenticated-avl-tree/Cargo.toml
@@ -16,7 +16,7 @@ ergo-lib-utils = { path = "../ergo-lib-utils" }
 getrandom = { version = "0.2.9", features = ["js"] }
 bytes = { version = "1.0.1" }
 base16 = "0.2.1"
-
+console_error_panic_hook = "0.1.7"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.0"

--- a/packages/authenticated-avl-tree/package.json
+++ b/packages/authenticated-avl-tree/package.json
@@ -21,5 +21,9 @@
   "module": "dist/esm/authenticated_avl_tree.js",
   "types": "dist/node/authenticated_avl_tree.d.ts",
   "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ergoplatform/ergo-lib-wasm.git"
+  },
   "license": "CC0-1.0"
 }

--- a/packages/authenticated-avl-tree/src/lib.rs
+++ b/packages/authenticated-avl-tree/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod batch_avl_prover;
 pub mod batch_node;
 pub mod operation;
+
+ergo_lib_utils::impl_set_console_panic_hook_fn!();

--- a/packages/ergo-lib-utils/src/lib.rs
+++ b/packages/ergo-lib-utils/src/lib.rs
@@ -37,3 +37,17 @@ where
         self.map_err(|e| JsValue::from_str(format!("js error occurred: {:?}", e).as_str()))
     }
 }
+
+#[macro_export]
+macro_rules! impl_set_console_panic_hook_fn {
+    () => {
+        /// Set a panic hook that provides richer debug/stack trace information
+        /// on errors that occur in WASM code.
+        ///
+        /// Call this function in the entrypoint of your application.
+        #[wasm_bindgen::prelude::wasm_bindgen(js_name = "__setConsolePanicHook")]
+        pub fn set_console_panic_hook() {
+            console_error_panic_hook::set_once()
+        }
+    };
+}

--- a/packages/ergo-lib-wasm/Cargo.toml
+++ b/packages/ergo-lib-wasm/Cargo.toml
@@ -19,6 +19,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.91"
 ergo-wasm-derive = { path = "../ergo-wasm-derive" }
 num-traits = "0.2.15"
+console_error_panic_hook = "0.1.7"
+ergo-lib-utils = { path = "../ergo-lib-utils" }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"

--- a/packages/ergo-lib-wasm/package.json
+++ b/packages/ergo-lib-wasm/package.json
@@ -23,5 +23,9 @@
   "license": "CC0-1.0",
   "devDependencies": {
     "jest-each": "^29.3.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ergoplatform/ergo-lib-wasm.git"
   }
 }

--- a/packages/ergo-lib-wasm/src/lib.rs
+++ b/packages/ergo-lib-wasm/src/lib.rs
@@ -19,3 +19,5 @@ pub mod prelude {
     pub use crate::traits::{MapJsValueErrorResult, TryJsArrayToVec, TryVecToJsArray};
     pub use crate::{impl_json_methods, impl_try_js_array_to_vec, impl_try_vec_to_js_array};
 }
+
+ergo_lib_utils::impl_set_console_panic_hook_fn!();

--- a/packages/scorex-buffer/Cargo.toml
+++ b/packages/scorex-buffer/Cargo.toml
@@ -11,3 +11,4 @@ wasm-bindgen = "0.2.83"
 sigma-ser = "0.11.0"
 js-sys = "0.3.60"
 ergo-lib-utils = { path = "../ergo-lib-utils" }
+console_error_panic_hook = "0.1.7"

--- a/packages/scorex-buffer/package.json
+++ b/packages/scorex-buffer/package.json
@@ -20,5 +20,9 @@
   "module": "dist/esm/scorex_buffer.js",
   "types": "dist/node/scorex_buffer.d.ts",
   "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ergoplatform/ergo-lib-wasm.git"
+  },
   "license": "CC0-1.0"
 }

--- a/packages/scorex-buffer/src/lib.rs
+++ b/packages/scorex-buffer/src/lib.rs
@@ -5,6 +5,8 @@ use js_sys::Uint8Array;
 use sigma_ser::vlq_encode::{ReadSigmaVlqExt, WriteSigmaVlqExt};
 use wasm_bindgen::prelude::*;
 
+ergo_lib_utils::impl_set_console_panic_hook_fn!();
+
 #[wasm_bindgen]
 pub struct ScorexWriter(Vec<u8>);
 


### PR DESCRIPTION
- Expose a `__setConsolePanicHook` function in all packages to allow package consumers to gather more detailed stack traces for WASM errors
- Enable NPM provenance (hopefully)