### PR TITLE
Fix GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,8 +11,6 @@ jobs:
   release:
     name: Release or Publish
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
This seems to have removed needed permissions for Github actions bot to run `changesets`, revert to previous permissions