### PR TITLE
Use shorthand repository field in package.json

### DIFF
--- a/.changeset/lazy-clocks-lie.md
+++ b/.changeset/lazy-clocks-lie.md
@@ -1,0 +1,7 @@
+---
+"@ergoplatform/authenticated-avl-tree": patch
+"@ergoplatform/ergo-lib-wasm": patch
+"@ergoplatform/scorex-buffer": patch
+---
+
+update repository field in package.json

--- a/packages/authenticated-avl-tree/package.json
+++ b/packages/authenticated-avl-tree/package.json
@@ -21,9 +21,6 @@
   "module": "dist/esm/authenticated_avl_tree.js",
   "types": "dist/node/authenticated_avl_tree.d.ts",
   "sideEffects": false,
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/ergoplatform/ergo-lib-wasm.git"
-  },
+  "repository": "ergoplatform/ergo-lib-wasm",
   "license": "CC0-1.0"
 }

--- a/packages/ergo-lib-wasm/package.json
+++ b/packages/ergo-lib-wasm/package.json
@@ -24,8 +24,5 @@
   "devDependencies": {
     "jest-each": "^29.3.1"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/ergoplatform/ergo-lib-wasm.git"
-  }
+  "repository": "ergoplatform/ergo-lib-wasm"
 }

--- a/packages/scorex-buffer/package.json
+++ b/packages/scorex-buffer/package.json
@@ -20,9 +20,6 @@
   "module": "dist/esm/scorex_buffer.js",
   "types": "dist/node/scorex_buffer.d.ts",
   "sideEffects": false,
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/ergoplatform/ergo-lib-wasm.git"
-  },
+  "repository": "ergoplatform/ergo-lib-wasm",
   "license": "CC0-1.0"
 }


### PR DESCRIPTION
Provanance failed, everything looks good though: https://github.com/ergoplatform/ergo-lib-wasm/actions/runs/5013017303/jobs/8985620347

Try shorthand repository setting as seen in some other project repos that successfully published, i.e: https://github.com/toeverything/blocksuite/commit/b6cb9111f9414b2de6b595ac3060ba0f14304f2f