### PR TITLE
Bump patch to fix broken publish

### DIFF
--- a/.changeset/pretty-ducks-wonder.md
+++ b/.changeset/pretty-ducks-wonder.md
@@ -1,0 +1,7 @@
+---
+"@ergoplatform/authenticated-avl-tree": patch
+"@ergoplatform/ergo-lib-wasm": patch
+"@ergoplatform/scorex-buffer": patch
+---
+
+bump patch to fix previously broken publish

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,10 +36,10 @@ jobs:
           toolchain: stable
       - name: Install wasm-pack
         run: cargo install wasm-pack
-      - name: Setup Node.js 18.x
+      - name: Setup Node.js 16.x
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 16.x
       - name: Install Dependencies
         run: yarn --frozen-lockfile
       - name: Build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,10 +19,10 @@ jobs:
           toolchain: stable
       - name: Install wasm-pack
         run: cargo install wasm-pack
-      - name: Setup Node.js 18.x
+      - name: Setup Node.js 16.x
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 16.x
       - name: Install Dependencies
         run: yarn --frozen-lockfile
       - name: Build


### PR DESCRIPTION
Last publish broke all packages, for some reason only `package.json` was included in the published NPM package.

Not sure what happened, the only thing that has changed that could be related to this that I can think of is the nodejs version but it seems unlikely this was the cause.